### PR TITLE
Substantially improve UAT uplink decode performance and build 1421 firmware with optimization

### DIFF
--- a/firmware/adsbee_1090/pico/host_test/test_reporting_beast.cc
+++ b/firmware/adsbee_1090/pico/host_test/test_reporting_beast.cc
@@ -151,13 +151,12 @@ TEST(BeastUtils, BuildFeedStartFrame) {
 }
 
 struct UATADSBPacketBeastTest {
-    DecodedUATADSBPacket packet;
+    RawUATADSBPacket packet;
     char beast_frame_buf[2 * BeastReporter::kUATADSBBeastFrameMaxLenBytes];
 };
 
 UATADSBPacketBeastTest uat_adsb_tests[] = {
-    {.packet =
-         DecodedUATADSBPacket("00a66ef135445d525a0c05191190212048006cb82bc4d53a5b2bb0a8ec6e", -60, 0, 0x123456 << 2),
+    {.packet = RawUATADSBPacket("00a66ef135445d525a0c05191190212048006cb82bc4d53a5b2bb0a8ec6e", -60, 0, 0x123456 << 2),
      .beast_frame_buf =
          "1aec730000001234562d"  // Prefix: escape | frame type | uat message type | mlat timestamp | rssi
          "00a66ef135445d525a0c05191190212048006cb82bc4d53a5b2bb0a8ec6e"}};
@@ -175,12 +174,12 @@ TEST(BeastUtils, BuildUATADSBFrame) {
 }
 
 struct UATUplinkPacketBeastTest {
-    DecodedUATUplinkPacket packet;
+    RawUATUplinkPacket packet;
     char beast_frame_buf[2 * BeastReporter::kUATUplinkBeastFrameMaxLenBytes];
 };
 
 UATUplinkPacketBeastTest uat_uplink_tests[] = {
-    {.packet = DecodedUATUplinkPacket(
+    {.packet = RawUATUplinkPacket(
          "352d30000000147058000000c9c70d000000523c3c000000d61f170000005cc7f1000000b60cd7000000b01f0c0000002ec7720000000"
          "08cd3000000001f1e0000003505330000000ef6c10000001d5ffc000000687c7500000022f5c300000010d91c0000000020b400000000"
          "51cb00000000600c000000ff4cf000000000f57f00000051541c00000091227000000054037f0000007c4f1e0000004d053000000050f"

--- a/firmware/adsbee_1090/pico/host_test/uat/test_uat_uplink.cc
+++ b/firmware/adsbee_1090/pico/host_test/uat/test_uat_uplink.cc
@@ -1,3 +1,5 @@
+#include <cstring>  // For memcmp / memcpy.
+
 #include "fec.hh"
 #include "gtest/gtest.h"
 #include "uat_packet.hh"
@@ -32,6 +34,46 @@ TEST(UATDecoderTest, UplinkEncodeDecode) {
     DecodedUATUplinkPacket bad_packet(RawUATUplinkPacket(encoded_data_frame, RawUATUplinkPacket::kUplinkMessageNumBytes,
                                                          sigs_dbm, sigq_bits, mlat_48mhz_64bit_counts));
     EXPECT_FALSE(bad_packet.is_valid);
+}
+
+// The decoder must leave raw.encoded_message as the corrected, interleaved codeword (payload AND parity) without a
+// separate re-encode pass: downstream consumers (CC1312 -> RP2040 SPI, RAW/BEAST output, GDL90 de-interleave) rely on
+// it. Inject errors at interleaved positions covering both data and parity symbols of every block and check that the
+// raw message is restored bit-exact.
+TEST(UATDecoderTest, UplinkCorrectsRawMessageInPlace) {
+    uint8_t payload[RawUATUplinkPacket::kUplinkMessagePayloadNumBytes];
+    for (uint16_t i = 0; i < sizeof(payload); i++) {
+        payload[i] = static_cast<uint8_t>((i * 37 + 11) & 0xFF);  // Deterministic non-trivial pattern.
+    }
+    uint8_t clean_encoded[RawUATUplinkPacket::kUplinkMessageNumBytes] = {0};
+    ASSERT_TRUE(uat_rs.EncodeUplinkMessage(clean_encoded, payload));
+
+    uint8_t corrupted[RawUATUplinkPacket::kUplinkMessageNumBytes];
+    memcpy(corrupted, clean_encoded, sizeof(corrupted));
+    // Byte indices within a de-interleaved 92-byte block: 0, 40, 71 are payload; 75, 91 are parity.
+    const uint16_t kBlockByteIndices[] = {0, 40, 71, 75, 91};
+    uint16_t num_errors = 0;
+    for (uint16_t block = 0; block < RawUATUplinkPacket::kUplinkMessageNumBlocks; block++) {
+        for (uint16_t byte_index : kBlockByteIndices) {
+            corrupted[byte_index * RawUATUplinkPacket::kUplinkMessageNumBlocks + block] ^= 0x5A;
+            num_errors++;
+        }
+    }
+    ASSERT_NE(memcmp(corrupted, clean_encoded, sizeof(corrupted)), 0);
+
+    DecodedUATUplinkPacket packet(RawUATUplinkPacket(corrupted, RawUATUplinkPacket::kUplinkMessageNumBytes, -10, 0, 0));
+    ASSERT_TRUE(packet.is_valid);
+    EXPECT_EQ(packet.raw.sigq_bits, num_errors);
+    EXPECT_EQ(memcmp(packet.decoded_payload, payload, sizeof(payload)), 0);
+    EXPECT_EQ(memcmp(packet.raw.encoded_message, clean_encoded, sizeof(clean_encoded)), 0);
+
+    // A second decode of the corrected raw message must be a clean pass (0 corrections) and de-interleaving it directly
+    // must yield the same payload -- this is what the GDL90 reporter relies on.
+    uint8_t redecoded_payload[RawUATUplinkPacket::kUplinkMessagePayloadNumBytes] = {0};
+    EXPECT_EQ(uat_rs.DecodeUplinkMessage(redecoded_payload, packet.raw.encoded_message), 0);
+    uint8_t deinterleaved_payload[RawUATUplinkPacket::kUplinkMessagePayloadNumBytes] = {0};
+    UATReedSolomon::DeInterleaveUplinkMessage(deinterleaved_payload, packet.raw.encoded_message);
+    EXPECT_EQ(memcmp(deinterleaved_payload, payload, sizeof(payload)), 0);
 }
 
 TEST(UATDecoderTest, UplinkFrames) {

--- a/firmware/adsbee_1421/ti/CMakeLists.txt
+++ b/firmware/adsbee_1421/ti/CMakeLists.txt
@@ -25,6 +25,15 @@ string(REGEX MATCH "gcc-arm-none-eabi-([0-9]+\\.[0-9]+\\.[0-9]+)" _ ${GCC_ARMCOM
 set(GCC_ARM_VERSION ${CMAKE_MATCH_1})
 message(STATUS "ARM GCC compiler version: ${GCC_ARM_VERSION}")
 
+# Default to an optimized build. custom_toolchain/gcc.cmake only adds -O3 under $<CONFIG:Release>
+# (and -O0 under $<CONFIG:Debug>), so a configure that omits -DCMAKE_BUILD_TYPE would otherwise
+# silently produce an unoptimized image (no -O flag at all) -- several times slower on the RS
+# decode / reporting hot paths. build.sh and CI always pass the type; this guards hand/IDE configures.
+if(NOT CMAKE_BUILD_TYPE)
+    set(CMAKE_BUILD_TYPE Release CACHE STRING "Build type (Release|Debug)" FORCE)
+endif()
+message(STATUS "Build type: ${CMAKE_BUILD_TYPE}")
+
 project(adsbee_1421 C CXX ASM)
 
 # Derive firmware version from the single source of truth in object_dictionary.cpp.

--- a/firmware/adsbee_1421/ti/adsbee.cpp
+++ b/firmware/adsbee_1421/ti/adsbee.cpp
@@ -116,8 +116,8 @@ void ADSBee::EnterSyncSleep() {
 
     // Let the console line go fully idle before sampling constraints below. UART2 holds
     // PowerCC26XX_DISALLOW_STANDBY from the start of a TX until its EOT interrupt, which lands after the
-    // last stop bit -- well after the write callback that iface_write()'s blocking wait keys off. Without
-    // this the CONSOLE_INFO above guarantees a spurious "STANDBY blocked" report on every sleep cycle.
+    // last stop bit -- and console output is queued asynchronously in a TX ring. Without this the
+    // CONSOLE_INFO above guarantees a spurious "STANDBY blocked" report on every sleep cycle.
     comms_manager.DrainConsoleTx();
 
     // On CC13x4 an enabled DIO interrupt is automatically a STANDBY wake source (the GPIO driver routes
@@ -336,12 +336,16 @@ bool ADSBee::SetWatchdogTimeoutSec(uint32_t timeout_sec) {
 
 void ADSBee::Reboot() {
     CONSOLE_INFO("ADSBee::Reboot", "Rebooting.");
+    // Console output is queued asynchronously; get it (and any pending AT response) onto the wire before the reset.
+    comms_manager.DrainConsoleTx();
     lr2021.DeInit();
     SysCtrlSystemReset();
 }
 
 void ADSBee::EnterUARTBootloader() {
     CONSOLE_INFO("ADSBee::EnterUARTBootloader", "Invalidating image and entering ROM UART bootloader.");
+    // Console output is queued asynchronously; get it (and any pending AT response) onto the wire before the reset.
+    comms_manager.DrainConsoleTx();
     lr2021.DeInit();
     // Mask interrupts and keep them masked through the reset: we are about to erase the vector
     // table sector, so no interrupt may fire afterwards. FlashSectorErase() and

--- a/firmware/adsbee_1421/ti/adsbee.hh
+++ b/firmware/adsbee_1421/ti/adsbee.hh
@@ -71,6 +71,11 @@ class ADSBee {
     // RX FIFO reads back completely full (the poll loop fell behind; frames were likely dropped).
     uint32_t lr2021_fifo_full_count = 0;
 
+    // Longest single super-loop iteration observed, in microseconds. Reported and reset via AT+RX_STATS. Every
+    // millisecond spent in one iteration is a millisecond the LR2021 FIFO isn't drained and AT commands aren't
+    // serviced, so this is the primary "is the receiver bogging down" gauge. Updated by main().
+    uint32_t max_loop_us = 0;
+
     SettingsManager::RxPosition rx_position;
     bool rx_position_available = false;
 

--- a/firmware/adsbee_1421/ti/cc13x4_cc26x4_nortos.lds
+++ b/firmware/adsbee_1421/ti/cc13x4_cc26x4_nortos.lds
@@ -30,7 +30,14 @@
  * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-STACKSIZE = 1024;
+/*
+ * The main stack lives directly above the heap (SP starts at _stack_end and grows down). The TI default of 1 kB is far
+ * too small for this application -- a single reporting pass stacks a 2 kB composite-array buffer, ~1 kB printf buffers
+ * and ~1 kB packet objects -- and an overflow silently walks into the (mostly idle) top of the heap. 32 kB is cheap:
+ * the CC1314R10 has 256 kB of SRAM and ~50 kB remains free after this (see the .map). The linker errors out if the
+ * SRAM budget is ever exceeded, so this cannot silently overlap other sections.
+ */
+STACKSIZE = 32768;
 HEAPSIZE = 16384; /* Size of heap buffer used by HeapMem */
 
 MEMORY

--- a/firmware/adsbee_1421/ti/comms/at/comms_at.cpp
+++ b/firmware/adsbee_1421/ti/comms/at/comms_at.cpp
@@ -314,11 +314,14 @@ CPP_AT_CALLBACK(CommsManager::ATRxStatsCallback) {
             }
             CPP_AT_CMD_PRINTF(
                 "=pkt_rx=%u,crc_error=%u,len_error=%u,pbl_det=%u,sync_ok=%u,sync_fail=%u,timeout=%u,"
-                "fifo_full=%lu,q_ovf=%lu,bitflips_fixed=%lu,uat_rx_restarts=%lu",
+                "fifo_full=%lu,q_ovf=%lu,bitflips_fixed=%lu,uat_rx_restarts=%lu,"
+                "max_loop_us=%lu,tx_stalls=%lu,tx_drops=%lu,tx_ring_hw=%u",
                 stats.pkt_rx, stats.crc_error, stats.len_error, stats.pbl_det, stats.sync_ok, stats.sync_fail,
                 stats.timeout, (unsigned long)adsbee.lr2021_fifo_full_count,
                 (unsigned long)packet_decoder.raw_queue_overflow_count,
-                (unsigned long)packet_decoder.bitflips_fixed_count, (unsigned long)subg_radio.rx_error_restart_count);
+                (unsigned long)packet_decoder.bitflips_fixed_count, (unsigned long)subg_radio.rx_error_restart_count,
+                (unsigned long)adsbee.max_loop_us, (unsigned long)comms_manager.uart_tx_stall_count,
+                (unsigned long)comms_manager.uart_tx_drop_count, comms_manager.uart_tx_high_water_bytes);
             CPP_AT_SILENT_SUCCESS();
             break;
         }
@@ -333,6 +336,10 @@ CPP_AT_CALLBACK(CommsManager::ATRxStatsCallback) {
             packet_decoder.raw_queue_overflow_count = 0;
             packet_decoder.bitflips_fixed_count = 0;
             subg_radio.rx_error_restart_count = 0;
+            adsbee.max_loop_us = 0;
+            comms_manager.uart_tx_stall_count = 0;
+            comms_manager.uart_tx_drop_count = 0;
+            comms_manager.uart_tx_high_water_bytes = 0;
             CPP_AT_SUCCESS();
             break;
         }
@@ -1047,7 +1054,9 @@ const CppAT::ATCommandDef_t at_command_list[] = {
      .max_args = 1,
      .help_string = "AT+RX_STATS?\r\n\tQuery LR2021 OOK Rx stats (pkt_rx, crc_error, len_error, pbl_det, sync_ok, "
                     "sync_fail, timeout) plus health counters (fifo_full, q_ovf, bitflips_fixed, "
-                    "uat_rx_restarts).\r\n\tAT+RX_STATS=RESET\r\n\tReset all Rx stats counters.",
+                    "uat_rx_restarts, max_loop_us = longest main loop iteration, tx_stalls / tx_drops / tx_ring_hw = "
+                    "console TX ring waits, dropped writes and peak occupancy in bytes).\r\n\tAT+RX_STATS=RESET\r\n\t"
+                    "Reset all Rx stats counters.",
      .callback = CPP_AT_BIND_MEMBER_CALLBACK(CommsManager::ATRxStatsCallback, comms_manager)},
     {.command = "SETTINGS",
      .min_args = 0,

--- a/firmware/adsbee_1421/ti/comms/comms.cpp
+++ b/firmware/adsbee_1421/ti/comms/comms.cpp
@@ -11,17 +11,70 @@
 #include <ti/devices/DeviceFamily.h>
 #include DeviceFamily_constructPath(inc/hw_memmap.h)
 #include DeviceFamily_constructPath(driverlib/uart.h)
+#include <ti/drivers/dpl/HwiP.h>
 /* clang-format on */
 
 static const CommsManager::ReportSink kReportingSinks[] = {SettingsManager::SerialInterface::kConsole};
 static const uint16_t kNumReportingSinks = sizeof(kReportingSinks) / sizeof(CommsManager::ReportSink);
+
+// Margin added to every baud-derived TX wait so tiny shortfalls don't get a zero-length budget.
+static const uint32_t kTxWaitMarginMs = 5;
 
 CommsManager::CommsManager(CommsManagerConfig config)
     : config_(config), at_parser_(CppAT(at_command_list, at_command_list_num_commands, true)) {}
 
 void CommsManager::uart_write_callback(UART2_Handle handle, void* buf, size_t count, void* userArg,
                                        int_fast16_t status) {
-    static_cast<CommsManager*>(userArg)->uart_tx_busy_ = false;
+    // HWI context. Retire the bytes the driver actually consumed (count can be short if the write was cancelled),
+    // then chain the next contiguous ring segment straight from here so the wire never idles between segments. The
+    // UART2CC26X2 driver clears its writeInUse flag before invoking this callback, so a nested UART2_write is accepted.
+    CommsManager* self = static_cast<CommsManager*>(userArg);
+    self->uart_tx_head_ = static_cast<uint16_t>((self->uart_tx_head_ + count) & (kUartTxRingBytes - 1));
+    self->uart_tx_in_progress_ = false;
+    if (status == UART2_STATUS_SUCCESS) {
+        self->KickTx();
+    }
+    // On cancel/error, leave the ring alone: SetBaudRate() resets it after close, and Update()'s safety re-kick covers
+    // anything else.
+}
+
+void CommsManager::KickTx() {
+    uint16_t head = uart_tx_head_;
+    uint16_t tail = uart_tx_tail_;
+    if (head == tail) {
+        uart_tx_in_progress_ = false;
+        return;  // Nothing queued.
+    }
+    // Longest contiguous run starting at head (stop at the end of the ring; the callback chains the wrapped part).
+    size_t count = tail > head ? static_cast<size_t>(tail - head) : static_cast<size_t>(kUartTxRingBytes - head);
+    uart_tx_in_progress_ = true;
+    // The driver internally restarts DMA in <=1024 B pieces until the whole count is out, so no chunking here.
+    int_fast16_t status = UART2_write(uart_handle_, &uart_tx_ring_[head], count, nullptr);
+    if (status != UART2_STATUS_SUCCESS) {
+        uart_tx_in_progress_ = false;  // Update() / the next iface_write will retry.
+    }
+}
+
+bool CommsManager::WaitForTxRingSpace(uint16_t num_bytes) {
+    if (TxRingFreeBytes() >= num_bytes) {
+        return true;
+    }
+    uart_tx_stall_count++;
+    // Budget: time for the shortfall to clock out at the current baud rate, doubled, plus margin. Bounded so a wedged
+    // UART degrades to dropped output rather than a frozen main loop.
+    uint32_t shortfall = num_bytes - TxRingFreeBytes();
+    uint32_t deadline_ms = get_time_since_boot_ms() + 2 * TxBytesToMs(shortfall) + kTxWaitMarginMs;
+    while (TxRingFreeBytes() < num_bytes && get_time_since_boot_ms() < deadline_ms) {
+        // Safety net: if a write callback was ever lost, restart the drain instead of timing out.
+        if (!uart_tx_in_progress_ && uart_tx_head_ != uart_tx_tail_) {
+            uintptr_t key = HwiP_disable();
+            if (!uart_tx_in_progress_) {
+                KickTx();
+            }
+            HwiP_restore(key);
+        }
+    }
+    return TxRingFreeBytes() >= num_bytes;
 }
 
 bool CommsManager::OpenUART(uint32_t baud) {
@@ -58,8 +111,16 @@ bool CommsManager::SetBaudRate(uint32_t baud) {
     // before the line reconfigures.
     DrainConsoleTx();
 
+    // The driver requires an unfinished asynchronous write to be cancelled before UART2_close().
+    if (uart_tx_in_progress_) {
+        UART2_writeCancel(uart_handle_);
+    }
     UART2_close(uart_handle_);
-    uart_tx_busy_ = false;  // The write callback will not fire after close.
+    // Whatever didn't make it out is gone with the old baud rate; start the ring clean. No callback can fire after
+    // close, so plain assignments are safe here.
+    uart_tx_head_ = 0;
+    uart_tx_tail_ = 0;
+    uart_tx_in_progress_ = false;
     config_.uart_baud_rate = baud;
     if (!OpenUART(baud)) {
         // Deterministic params make reopen failure effectively impossible, but fall back to the
@@ -78,24 +139,33 @@ bool CommsManager::SetBaudRate(uint32_t baud) {
     return baud == config_.uart_baud_rate;
 }
 
-bool CommsManager::DrainConsoleTx(uint32_t timeout_ms) {
+bool CommsManager::DrainConsoleTx(uint32_t timeout_margin_ms) {
     // Each stage gets its own budget rather than sharing one deadline: the stages wait on unrelated
     // events, and a slow first stage must not starve the second. The hardware stage is the one that
     // matters for STANDBY (it gates the UART's power constraint), so it is exactly the one that must
     // not be skipped after a long DMA wait.
 
-    // Software side: wait for the in-flight CALLBACK-mode write (if any) to complete. Worst pending
-    // chunk is kPrintfBufferMaxSize (1000 B), ~87 ms at 115200.
-    uint32_t deadline_ms = get_time_since_boot_ms() + timeout_ms;
-    while (uart_tx_busy_ && get_time_since_boot_ms() < deadline_ms) {
+    // Software side: wait for the TX ring to empty and the last CALLBACK-mode write to complete. Budget
+    // is what the queued bytes need at the current baud rate (doubled) plus the caller's margin.
+    uint32_t deadline_ms =
+        get_time_since_boot_ms() + 2 * TxBytesToMs(TxRingUsedBytes() + kPrintfBufferMaxSize) + timeout_margin_ms;
+    while ((uart_tx_in_progress_ || uart_tx_head_ != uart_tx_tail_) && get_time_since_boot_ms() < deadline_ms) {
+        // Safety net: restart the drain if a write callback was ever lost.
+        if (!uart_tx_in_progress_) {
+            uintptr_t key = HwiP_disable();
+            if (!uart_tx_in_progress_) {
+                KickTx();
+            }
+            HwiP_restore(key);
+        }
     }
     // Hardware side: the write callback fires on DMA completion, not when the bytes have left the
     // wire — up to a FIFO's worth can still be in flight. UARTBusy() stays set until the last stop
     // bit is shifted out.
-    deadline_ms = get_time_since_boot_ms() + timeout_ms;
+    deadline_ms = get_time_since_boot_ms() + timeout_margin_ms;
     while (UARTBusy(UART0_BASE) && get_time_since_boot_ms() < deadline_ms) {
     }
-    return !uart_tx_busy_ && !UARTBusy(UART0_BASE);
+    return !uart_tx_in_progress_ && uart_tx_head_ == uart_tx_tail_ && !UARTBusy(UART0_BASE);
 }
 
 bool CommsManager::Suspend() {
@@ -112,6 +182,16 @@ bool CommsManager::Resume() {
 }
 
 bool CommsManager::Update() {
+    // Safety net for the TX ring: if a kick failed (UART2_write rejected) or a callback was lost, restart the drain.
+    // In normal operation the write callback chains segments itself and this branch is never taken.
+    if (!uart_tx_in_progress_ && uart_tx_head_ != uart_tx_tail_) {
+        uintptr_t key = HwiP_disable();
+        if (!uart_tx_in_progress_) {
+            KickTx();
+        }
+        HwiP_restore(key);
+    }
+
     UpdateAT();
 
     uint32_t timestamp_ms = get_time_since_boot_ms();
@@ -175,7 +255,9 @@ int CommsManager::console_vprintf(const char* fmt, va_list args) {
     char buf[kPrintfBufferMaxSize];
     int len = vsnprintf(buf, kPrintfBufferMaxSize, fmt, args);
     if (len <= 0) return len;
-    return iface_puts(SettingsManager::SerialInterface::kConsole, buf, /*blocking=*/true) ? len : -1;
+    // Queued into the TX ring and sent in the background; callers that need the text on the wire (reboot, sleep,
+    // baud change) call DrainConsoleTx().
+    return iface_puts(SettingsManager::SerialInterface::kConsole, buf) ? len : -1;
 }
 
 int CommsManager::iface_printf(SettingsManager::SerialInterface iface, const char* format, ...) {
@@ -205,29 +287,56 @@ int CommsManager::iface_vprintf(SettingsManager::SerialInterface iface, const ch
 bool CommsManager::iface_write(SettingsManager::SerialInterface iface, const void* buf, size_t len, bool blocking) {
     switch (iface) {
         case SettingsManager::kConsole: {
-            // Send in chunks no larger than the single static TX buffer. Reporting batches can exceed
-            // kPrintfBufferMaxSize under heavy load; chunking lets the whole batch through instead of
-            // dropping it. The per-chunk busy-wait gates reuse of uart_tx_buf_ until the previous
-            // chunk's write callback fires.
+            (void)blocking;  // Data is copied into the ring; completion is never awaited here (see header).
+            if (uart_handle_ == nullptr) {
+                return false;  // Console not open yet (e.g. a static-init error print).
+            }
+            if (len == 0) {
+                return true;
+            }
             const uint8_t* p = static_cast<const uint8_t*>(buf);
             size_t remaining = len;
-            bool ok = true;
             while (remaining > 0) {
-                size_t chunk = remaining > kPrintfBufferMaxSize ? kPrintfBufferMaxSize : remaining;
-                while (uart_tx_busy_) {
+                // A write is normally queued whole (all-or-nothing, so a dropped write never leaves a partial frame
+                // on the wire). Only a write larger than the ring itself -- not reachable with the 2 kB composite
+                // array cap -- is fed through in ring-sized pieces.
+                uint16_t chunk = remaining < static_cast<size_t>(kUartTxRingBytes - 1)
+                                     ? static_cast<uint16_t>(remaining)
+                                     : static_cast<uint16_t>(kUartTxRingBytes - 1);
+                if (!WaitForTxRingSpace(chunk)) {
+                    uart_tx_drop_count++;
+                    return false;  // Link oversubscribed; drop rather than stall the receiver.
                 }
-                memcpy(uart_tx_buf_, p, chunk);
-                uart_tx_busy_ = true;
-                int_fast16_t status = UART2_write(uart_handle_, uart_tx_buf_, chunk, nullptr);
-                ok &= (status == UART2_STATUS_SUCCESS);
+
+                // Copy outside the critical section: [tail, tail + chunk) is exclusively the producer's -- the
+                // consumer only ever reads up to the published tail, and free space can only grow underneath us.
+                uint16_t tail = uart_tx_tail_;
+                uint16_t first = static_cast<uint16_t>(kUartTxRingBytes - tail);
+                if (first > chunk) {
+                    first = chunk;
+                }
+                memcpy(&uart_tx_ring_[tail], p, first);
+                if (chunk > first) {
+                    memcpy(&uart_tx_ring_[0], p + first, chunk - first);  // Wrapped remainder.
+                }
+
+                // Publish and, if the UART is idle, start it. Both under HWI-disable so the write callback (which
+                // reads tail and may clear in_progress) can't interleave with the publish/kick decision.
+                uintptr_t key = HwiP_disable();
+                uart_tx_tail_ = static_cast<uint16_t>((tail + chunk) & (kUartTxRingBytes - 1));
+                uint16_t used = TxRingUsedBytes();
+                if (used > uart_tx_high_water_bytes) {
+                    uart_tx_high_water_bytes = used;
+                }
+                if (!uart_tx_in_progress_) {
+                    KickTx();
+                }
+                HwiP_restore(key);
+
                 p += chunk;
                 remaining -= chunk;
             }
-            if (blocking) {
-                while (uart_tx_busy_) {
-                }
-            }
-            return ok;
+            return true;
         }
         case SettingsManager::kNumSerialInterfaces:
         default:

--- a/firmware/adsbee_1421/ti/comms/comms.hh
+++ b/firmware/adsbee_1421/ti/comms/comms.hh
@@ -26,6 +26,12 @@ class CommsManager {
 
     static constexpr uint16_t kATCommandBufMaxLen = 1000;
     static constexpr uint16_t kPrintfBufferMaxSize = 1000;
+    // Software TX ring behind the console UART. Sized to absorb a full worst-case raw reporting batch (~4.6 kB of RAW
+    // hex for a 2 kB composite array of uplinks) plus console traffic without the main loop ever waiting on the wire:
+    // at 1 Mbaud the ring drains in ~80 ms, well inside the 50 ms reporting tick for a typical batch. Must be a power
+    // of two.
+    static constexpr uint16_t kUartTxRingBytes = 8192;
+    static_assert((kUartTxRingBytes & (kUartTxRingBytes - 1)) == 0, "kUartTxRingBytes must be a power of two.");
 
     struct CommsManagerConfig {
         uint8_t uart_index = bsp.kSubGUARTIndex;
@@ -67,17 +73,32 @@ class CommsManager {
 
     /**
      * Blocks until all queued console TX bytes have physically left the wire. Two stages are needed:
-     * the write callback fires on DMA completion, but up to a FIFO's worth of bytes can still be
-     * shifting out afterwards. Callers that need the line truly idle -- a baud change, or entering
-     * STANDBY (UART2 holds a PowerCC26XX_DISALLOW_STANDBY constraint until its EOT interrupt, which
-     * lands after the last stop bit) -- must wait for both.
-     * @param[in] timeout_ms Budget for each stage separately, so a slow first stage cannot starve the
-     *                       second and a wedged UART cannot hang the caller; the worst case for the
-     *                       call as a whole is therefore 2 * timeout_ms. The default covers a full
-     *                       kPrintfBufferMaxSize chunk (~87 ms at 115200).
+     * first the software TX ring must empty and the last DMA write callback fire, but up to a FIFO's
+     * worth of bytes can still be shifting out afterwards. Callers that need the line truly idle -- a
+     * baud change, entering STANDBY (UART2 holds a PowerCC26XX_DISALLOW_STANDBY constraint until its
+     * EOT interrupt, which lands after the last stop bit), or a reboot -- must wait for both.
+     * @param[in] timeout_margin_ms Extra budget added to each stage on top of the time the bytes
+     *                              currently queued need to drain at the configured baud rate, so a
+     *                              wedged UART cannot hang the caller. Worst case for the call as a
+     *                              whole is roughly 2 * (ring drain time + timeout_margin_ms); a full
+     *                              8 kB ring is ~80 ms at 1 Mbaud, ~710 ms at 115200.
      * @retval True if the line went idle, false if the timeout expired first.
      */
-    bool DrainConsoleTx(uint32_t timeout_ms = 200);
+    bool DrainConsoleTx(uint32_t timeout_margin_ms = 200);
+
+    /**
+     * Number of bytes currently waiting in the software TX ring (excludes bytes already handed to the
+     * UART DMA / FIFO).
+     */
+    inline uint16_t TxRingUsedBytes() const {
+        return static_cast<uint16_t>((uart_tx_tail_ - uart_tx_head_) & (kUartTxRingBytes - 1));
+    }
+    inline uint16_t TxRingFreeBytes() const { return kUartTxRingBytes - 1 - TxRingUsedBytes(); }
+
+    // TX ring statistics, surfaced via AT+RX_STATS. Cleared by AT+RX_STATS=RESET.
+    uint32_t uart_tx_stall_count = 0;      // Writes that had to wait for ring space (link oversubscribed).
+    uint32_t uart_tx_drop_count = 0;       // Writes dropped whole after the bounded wait expired.
+    uint16_t uart_tx_high_water_bytes = 0;  // Peak ring occupancy observed.
 
     /**
      * Change the console UART baud rate at runtime. TI's UART2 driver has no live baud-change API, so
@@ -122,6 +143,19 @@ class CommsManager {
 
     int iface_printf(SettingsManager::SerialInterface iface, const char* format, ...);
     int iface_vprintf(SettingsManager::SerialInterface iface, const char* format, va_list args);
+    /**
+     * Queue bytes for transmission on a serial interface. Copies buf into the software TX ring and returns as soon
+     * as the bytes are queued; the UART DMA drains the ring in the background (write callback chains segments), so
+     * the main loop never waits on the wire in steady state. If the ring lacks room for the whole write, waits a
+     * bounded time (what the shortfall needs to drain at the current baud, doubled) for room and, failing that,
+     * drops the whole write (never a partial frame) and counts it in uart_tx_drop_count.
+     * @param[in] iface Interface to write to.
+     * @param[in] buf Bytes to write. Copied; need not outlive the call.
+     * @param[in] len Number of bytes.
+     * @param[in] blocking Retained for API compatibility; the data is copied so completion is never awaited here.
+     *                     Callers that need the wire idle (baud change, sleep, reboot) use DrainConsoleTx().
+     * @retval True if all bytes were queued, false if the write was dropped or the interface is unavailable.
+     */
     bool iface_write(SettingsManager::SerialInterface iface, const void* buf, size_t len, bool blocking = false);
     bool iface_putc(SettingsManager::SerialInterface iface, char c, bool blocking = false);
     bool iface_getc(SettingsManager::SerialInterface iface, char& c);
@@ -176,14 +210,42 @@ class CommsManager {
     // Opens the console UART at the given baud rate and enables RX. Used by Init() and SetBaudRate().
     bool OpenUART(uint32_t baud);
 
+    /**
+     * Starts a UART2 write for the contiguous segment at the head of the TX ring, if the ring is non-empty. Sets
+     * uart_tx_in_progress_ accordingly. Must be called either with HWIs disabled (main loop) or from the UART write
+     * callback (HWI context, which the main loop cannot preempt) so that head/tail/in_progress are read consistently.
+     */
+    void KickTx();
+
+    /**
+     * Waits (bounded) for at least num_bytes of free space in the TX ring. Bound = time for the shortfall to drain at
+     * the current baud rate, doubled, plus a small margin. Also re-kicks the UART if a write callback was lost.
+     * @retval True if the space is available, false if the wait timed out.
+     */
+    bool WaitForTxRingSpace(uint16_t num_bytes);
+
+    /**
+     * Milliseconds needed to clock num_bytes out at the current baud rate (10 bits per byte), rounded up.
+     */
+    inline uint32_t TxBytesToMs(uint32_t num_bytes) const {
+        return (num_bytes * 10u * 1000u + config_.uart_baud_rate - 1) / config_.uart_baud_rate;
+    }
+
     CommsManagerConfig config_;
 
     // Console Settings
     CppAT at_parser_;
 
-    UART2_Handle uart_handle_;
-    volatile bool uart_tx_busy_ = false;
-    char uart_tx_buf_[kPrintfBufferMaxSize];
+    UART2_Handle uart_handle_ = nullptr;
+
+    // Software TX ring. Producer: iface_write (main loop) advances uart_tx_tail_. Consumer: KickTx() hands the
+    // contiguous segment at uart_tx_head_ to UART2_write; uart_write_callback (HWI context) advances uart_tx_head_ by
+    // the bytes the driver consumed and chains the next segment. One slot is kept free to distinguish full from
+    // empty. All cross-context updates happen with HWIs disabled or inside the callback.
+    uint8_t uart_tx_ring_[kUartTxRingBytes];
+    volatile uint16_t uart_tx_head_ = 0;
+    volatile uint16_t uart_tx_tail_ = 0;
+    volatile bool uart_tx_in_progress_ = false;  // A UART2_write is outstanding (its callback has not fired yet).
     static void uart_write_callback(UART2_Handle handle, void* buf, size_t count, void* userArg, int_fast16_t status);
 
     // Queue for holding new transponder packets before they get reported.

--- a/firmware/adsbee_1421/ti/comms/comms.hh
+++ b/firmware/adsbee_1421/ti/comms/comms.hh
@@ -87,8 +87,11 @@ class CommsManager {
     bool DrainConsoleTx(uint32_t timeout_margin_ms = 200);
 
     /**
-     * Number of bytes currently waiting in the software TX ring (excludes bytes already handed to the
-     * UART DMA / FIFO).
+     * Number of bytes currently occupying the software TX ring. This INCLUDES the segment already handed
+     * to UART2_write() but not yet retired: uart_tx_head_ only advances in the write callback, so bytes
+     * stay accounted for until the driver reports them consumed. That makes this the right figure for
+     * drain-time estimates and the high-water stat (it is everything not yet confirmed out of the ring),
+     * not a count of bytes still awaiting a UART2_write.
      */
     inline uint16_t TxRingUsedBytes() const {
         return static_cast<uint16_t>((uart_tx_tail_ - uart_tx_head_) & (kUartTxRingBytes - 1));

--- a/firmware/adsbee_1421/ti/main.cpp
+++ b/firmware/adsbee_1421/ti/main.cpp
@@ -15,6 +15,7 @@ extern "C" {
 #include "adsbee.hh"
 #include "bsp.hh"
 #include "comms.hh"
+#include "hal.hh"  // For get_time_since_boot_us.
 #include "led.hh"
 #include "object_dictionary.hh"
 #include "packet_decoder.hh"
@@ -148,6 +149,7 @@ int main(void) {
             continue;
         }
 
+        uint64_t loop_start_us = get_time_since_boot_us();
         leds.Update();
         // leds.FlashLED(bsp.k1090LEDPin, 100);  // Flash the LED for 100ms.
         // usleep(1000000);                        // Sleep for 1 second.
@@ -157,5 +159,10 @@ int main(void) {
         subg_radio.Update();
         uat_packet_decoder.Update();
         comms_manager.Update();
+        // Track the longest loop iteration (AT+RX_STATS max_loop_us) as the receiver's stall gauge.
+        uint32_t loop_us = static_cast<uint32_t>(get_time_since_boot_us() - loop_start_us);
+        if (loop_us > adsbee.max_loop_us) {
+            adsbee.max_loop_us = loop_us;
+        }
     }
 }

--- a/firmware/adsbee_1421/ti/object_dictionary/object_dictionary.cpp
+++ b/firmware/adsbee_1421/ti/object_dictionary/object_dictionary.cpp
@@ -4,7 +4,7 @@ const uint8_t ObjectDictionary::kFirmwareVersionMajor = 0;
 const uint8_t ObjectDictionary::kFirmwareVersionMinor = 3;
 const uint8_t ObjectDictionary::kFirmwareVersionPatch = 7;
 // NOTE: Indicate a final release with RC = 0.
-const uint8_t ObjectDictionary::kFirmwareVersionReleaseCandidate = 1;
+const uint8_t ObjectDictionary::kFirmwareVersionReleaseCandidate = 0;
 
 const uint32_t ObjectDictionary::kFirmwareVersion = (kFirmwareVersionMajor << 24) | (kFirmwareVersionMinor << 16) |
                                                     (kFirmwareVersionPatch << 8) | kFirmwareVersionReleaseCandidate;

--- a/firmware/adsbee_1421/ti/sub_ghz_radio/uat_packet_decoder.cpp
+++ b/firmware/adsbee_1421/ti/sub_ghz_radio/uat_packet_decoder.cpp
@@ -64,15 +64,22 @@ bool UATPacketDecoder::Update() {
 
         if (decoded_packet.is_valid) {
             leds.FlashLED(bsp.kSubGLEDPin, 50);
-            CONSOLE_INFO("UATPacketDecoder::Update", "+[%02dFIXD     ] len=%d rssi=%d ts=%lu",
-                         decoded_packet.raw.sigq_bits, RawUATUplinkPacket::kUplinkMessageNumBytes, packet.sigs_dbm,
-                         packet.mlat_48mhz_64bit_counts);
             if (!decoded_uat_uplink_packet_out_queue.Enqueue(decoded_packet)) {
                 CONSOLE_ERROR("UATPacketDecoder::Update", "UAT uplink decoded output queue overflowed.");
             }
-        } else {
-            CONSOLE_INFO("UATPacketDecoder::Update", "+[     INVLD] len=%d rssi=%d ts=%lu",
-                         RawUATUplinkPacket::kUplinkMessageNumBytes, packet.sigs_dbm, packet.mlat_48mhz_64bit_counts);
+        }
+
+        // Per-packet prints, gated on log level up front (mirrors the ADS-B path above).
+        if (settings_manager.settings.log_level >= SettingsManager::LogLevel::kInfo) {
+            if (decoded_packet.is_valid) {
+                CONSOLE_INFO("UATPacketDecoder::Update", "+[%02dFIXD     ] len=%d rssi=%d ts=%lu",
+                             decoded_packet.raw.sigq_bits, RawUATUplinkPacket::kUplinkMessageNumBytes,
+                             packet.sigs_dbm, packet.mlat_48mhz_64bit_counts);
+            } else {
+                CONSOLE_INFO("UATPacketDecoder::Update", "+[     INVLD] len=%d rssi=%d ts=%lu",
+                             RawUATUplinkPacket::kUplinkMessageNumBytes, packet.sigs_dbm,
+                             packet.mlat_48mhz_64bit_counts);
+            }
         }
     }
     return true;

--- a/firmware/common/adsb/uat_packet.cpp
+++ b/firmware/common/adsb/uat_packet.cpp
@@ -378,25 +378,21 @@ DecodedUATUplinkPacket::DecodedUATUplinkPacket(const RawUATUplinkPacket& packet)
 
 void DecodedUATUplinkPacket::ConstructUATUplinkPacket(bool run_fec) {
     if (run_fec) {
-        // Check if the packet is valid by validating the Reed-Solomon code.
-        // We don't actually know the number of bits with high certainty. First interpret as a long ADS-B message,
-        // and if that doesn't work, try it as a short ADS-B message. Decoding only available on CC1312 and in
-        // non-embedded unit tests.
+        // Check if the packet is valid by validating the Reed-Solomon code. Decoding only available on the TI RF MCUs
+        // (CC1312 coprocessor / CC1314 m1421) and in non-embedded unit tests; everyone else receives pre-corrected raw
+        // packets.
 #if defined(ON_TI) || defined(ON_HOST)
+        // DecodeUplinkMessage fills decoded_payload AND corrects raw.encoded_message in place, so the raw packet we pass
+        // around downstream (SPI to the RP2040, RAW/BEAST/GDL90 reporting) is already a corrected, interleaved codeword.
+        // No re-encode pass is needed.
         raw.sigq_bits = uat_rs.DecodeUplinkMessage(decoded_payload, raw.encoded_message);
-        if (raw.sigq_bits >= 0) {
-            CONSOLE_INFO("DecodedUATADSBPacket", "Decoded UAT uplink message with %d bytes corrected.", raw.sigq_bits);
-
-            // Now, encode the decoded payload back into the encoded message buf, so we are passing around a corrected
-            // message with parity and interleaving.
-            uat_rs.EncodeUplinkMessage(raw.encoded_message, decoded_payload);
-        } else {
+        if (raw.sigq_bits < 0) {
             is_valid = false;
             return;
         }
 #else
         // No FEC correction required, just de-interleave the payload and use it as is (it's already corrected).
-        uat_rs.DeInterleaveUplinkMessage(decoded_payload, raw.encoded_message);
+        UATReedSolomon::DeInterleaveUplinkMessage(decoded_payload, raw.encoded_message);
 #endif
     }
 

--- a/firmware/common/comms/beast/beast_utils.cpp
+++ b/firmware/common/comms/beast/beast_utils.cpp
@@ -156,9 +156,9 @@ uint16_t WriteBufferAsHexASCII(uint8_t *to_buf, const uint8_t *from_buf, uint16_
     return from_buf_num_bytes * 2;
 }
 
-uint16_t BeastReporter::BuildUATADSBBeastFrame(uint8_t *beast_frame_buf, const DecodedUATADSBPacket &packet) {
+uint16_t BeastReporter::BuildUATADSBBeastFrame(uint8_t *beast_frame_buf, const RawUATADSBPacket &packet) {
     char uat_message_type_char = ' ';
-    switch (packet.raw.buffer_len_bytes) {
+    switch (packet.buffer_len_bytes) {
         case RawUATADSBPacket::kShortADSBMessageNumBytes:
             // Short UAT ADSB message.
             uat_message_type_char = kUATMessageTypeADSBShort;
@@ -169,7 +169,7 @@ uint16_t BeastReporter::BuildUATADSBBeastFrame(uint8_t *beast_frame_buf, const D
             break;
         default:
             CONSOLE_ERROR("BeastReporter::BuildUATADSBBeastFrame", "Invalid UAT ADSB message length %d bytes.",
-                          packet.raw.buffer_len_bytes);
+                          packet.buffer_len_bytes);
             return 0;  // Invalid length.
     }
 
@@ -178,19 +178,19 @@ uint16_t BeastReporter::BuildUATADSBBeastFrame(uint8_t *beast_frame_buf, const D
     beast_frame_buf[bytes_written++] = BeastFrameType::kBeastFrameTypeUAT;
     beast_frame_buf[bytes_written++] = uat_message_type_char;
 
-    bytes_written += Write12MHzMLATTimestamp(beast_frame_buf + bytes_written, packet.raw.GetMLAT12MHzCounter());
-    bytes_written += WriteRSSIdBmAsBeastPowerLevel(beast_frame_buf + bytes_written, packet.raw.sigs_dbm);
+    bytes_written += Write12MHzMLATTimestamp(beast_frame_buf + bytes_written, packet.GetMLAT12MHzCounter());
+    bytes_written += WriteRSSIdBmAsBeastPowerLevel(beast_frame_buf + bytes_written, packet.sigs_dbm);
 
-    bytes_written += WriteBufferWithBeastEscapes(beast_frame_buf + bytes_written, packet.raw.buffer,
-                                                 packet.raw.buffer_len_bytes);
+    bytes_written += WriteBufferWithBeastEscapes(beast_frame_buf + bytes_written, packet.buffer,
+                                                 packet.buffer_len_bytes);
 
     return bytes_written;
 }
 
-uint16_t BeastReporter::BuildUATUplinkBeastFrame(uint8_t *beast_frame_buf, const DecodedUATUplinkPacket &packet) {
-    if (packet.raw.encoded_message_len_bytes != RawUATUplinkPacket::kUplinkMessageNumBytes) {
+uint16_t BeastReporter::BuildUATUplinkBeastFrame(uint8_t *beast_frame_buf, const RawUATUplinkPacket &packet) {
+    if (packet.encoded_message_len_bytes != RawUATUplinkPacket::kUplinkMessageNumBytes) {
         CONSOLE_ERROR("BeastReporter::BuildUATUplinkBeastFrame", "Invalid UAT Uplink message length %d bytes.",
-                      packet.raw.encoded_message_len_bytes);
+                      packet.encoded_message_len_bytes);
         return 0;  // Invalid length.
     }
 
@@ -199,11 +199,11 @@ uint16_t BeastReporter::BuildUATUplinkBeastFrame(uint8_t *beast_frame_buf, const
     beast_frame_buf[bytes_written++] = BeastFrameType::kBeastFrameTypeUAT;
     beast_frame_buf[bytes_written++] = kUATMessageTypeUplink;
 
-    bytes_written += Write12MHzMLATTimestamp(beast_frame_buf + bytes_written, packet.raw.GetMLAT12MHzCounter());
-    bytes_written += WriteRSSIdBmAsBeastPowerLevel(beast_frame_buf + bytes_written, packet.raw.sigs_dbm);
+    bytes_written += Write12MHzMLATTimestamp(beast_frame_buf + bytes_written, packet.GetMLAT12MHzCounter());
+    bytes_written += WriteRSSIdBmAsBeastPowerLevel(beast_frame_buf + bytes_written, packet.sigs_dbm);
 
-    bytes_written += WriteBufferWithBeastEscapes(beast_frame_buf + bytes_written, packet.raw.encoded_message,
-                                                 packet.raw.encoded_message_len_bytes);
+    bytes_written += WriteBufferWithBeastEscapes(beast_frame_buf + bytes_written, packet.encoded_message,
+                                                 packet.encoded_message_len_bytes);
 
     return bytes_written;
 }

--- a/firmware/common/comms/beast/beast_utils.hh
+++ b/firmware/common/comms/beast/beast_utils.hh
@@ -99,17 +99,21 @@ uint16_t BuildModeSIngestBeastFrame(uint8_t *beast_frame_buf, const DecodedModeS
 /**
  * Write a UAT ADSB frame.
  * @param[out] beast_frame_buf Pointer to byte buffer to fill with payload.
- * @param[in] packet Reference to DecodedUATADSBPacket to write to the buffer.
+ * @param[in] packet Reference to RawUATADSBPacket to write to the buffer. Takes the raw packet (not the decoded one) so
+ * that callers holding raw packets don't trigger an implicit DecodedUATADSBPacket construction (a full RS decode on
+ * FEC-capable platforms) just to build a frame.
  * @retval Number of bytes written to beast_frame_buf.
  */
-uint16_t BuildUATADSBBeastFrame(uint8_t *beast_frame_buf, const DecodedUATADSBPacket &packet);
+uint16_t BuildUATADSBBeastFrame(uint8_t *beast_frame_buf, const RawUATADSBPacket &packet);
 
 /**
  * Write a UAT uplink frame.
  * @param[out] beast_frame_buf Pointer to byte buffer to fill with payload.
- * @param[in] packet Reference to DecodedUATUplinkPacket to write to the buffer.
+ * @param[in] packet Reference to RawUATUplinkPacket to write to the buffer. Takes the raw packet (not the decoded one)
+ * so that callers holding raw packets don't trigger an implicit DecodedUATUplinkPacket construction (6 RS block
+ * decodes on FEC-capable platforms) just to build a frame.
  * @retval Number of bytes written to beast_frame_buf.
  */
-uint16_t BuildUATUplinkBeastFrame(uint8_t *beast_frame_buf, const DecodedUATUplinkPacket &packet);
+uint16_t BuildUATUplinkBeastFrame(uint8_t *beast_frame_buf, const RawUATUplinkPacket &packet);
 
 }  // namespace BeastReporter

--- a/firmware/common/comms/comms_reporting.cpp
+++ b/firmware/common/comms/comms_reporting.cpp
@@ -10,6 +10,7 @@
 #include "csbee_utils.hh"
 #include "gdl90_utils.hh"
 #include "mavlink_utils.hh"
+#include "fec.hh"        // For UATReedSolomon::DeInterleaveUplinkMessage.
 #include "raw_utils.hh"
 #include "uat_packet.hh"  // For DecodedUATUplinkPacket.
 
@@ -270,6 +271,9 @@ bool CommsManager::UpdateReporting(const ReportSink* sinks, const SettingsManage
 }
 
 bool CommsManager::ReportRaw(ReportSink* sinks, uint16_t num_sinks, const CompositeArray::RawPackets& packets) {
+    if (num_sinks == 0) {
+        return true;  // Nobody is listening; don't spend time building frames.
+    }
     char error_msg[CompositeArray::RawPackets::kErrorMessageMaxLen] = {0};
     if (!packets.IsValid(error_msg)) {
         CONSOLE_ERROR("CommsManager::ReportRaw", "Invalid CompositeArray::RawPackets: %s", error_msg);
@@ -328,6 +332,9 @@ bool CommsManager::ReportRaw(ReportSink* sinks, uint16_t num_sinks, const Compos
 
 bool CommsManager::ReportBeast(ReportSink* sinks, uint16_t num_sinks, const CompositeArray::RawPackets& packets,
                                SettingsManager::ReportingProtocol protocol) {
+    if (num_sinks == 0) {
+        return true;  // Nobody is listening; don't spend time building frames.
+    }
     char error_msg[CompositeArray::RawPackets::kErrorMessageMaxLen] = {0};
     if (!packets.IsValid(error_msg)) {
         CONSOLE_ERROR("CommsManager::ReportBeast", "Invalid CompositeArray::RawPackets: %s", error_msg);
@@ -722,21 +729,28 @@ bool CommsManager::ReportAircraftJSON(ReportSink* sinks, uint16_t num_sinks) {
 }
 
 bool CommsManager::ReportGDL90Uplink(ReportSink* sinks, uint16_t num_sinks, const CompositeArray::RawPackets& packets) {
+    if (num_sinks == 0) {
+        return true;  // Nobody is listening; don't spend time building frames.
+    }
     bool ret = true;
 
     for (uint16_t i = 0; i < packets.header->num_uat_uplink_packets; i++) {
-        // We need to decode the packet since GDL90 expects just the decoded payload. This double decoding is a bit
-        // wasteful but lets us use a common interface for reporting raw packets, instead of requiring decoded UAT
-        // uplink packets to be passed into special snowflake GDL90 reporting functions.
-        DecodedUATUplinkPacket packet = DecodedUATUplinkPacket(packets.uat_uplink_packets[i]);
-        if (!packet.is_valid) {
-            CONSOLE_WARNING("CommsManager::ReportGDL90Uplink", "Invalid UAT uplink packet encountered, skipping.");
+        // GDL90 carries just the de-interleaved 432-byte payload. Raw uplink packets that reach the reporting queues
+        // have already been FEC-corrected in place by the decoder (RS-capable platforms) or arrived pre-corrected
+        // (everyone else), so a plain de-interleave is all that's needed here -- no second RS pass.
+        const RawUATUplinkPacket& raw = packets.uat_uplink_packets[i];
+        if (raw.encoded_message_len_bytes != RawUATUplinkPacket::kUplinkMessageNumBytes) {
+            CONSOLE_WARNING("CommsManager::ReportGDL90Uplink", "Invalid UAT uplink packet length %d, skipping.",
+                            raw.encoded_message_len_bytes);
             continue;
         }
+        uint8_t payload[DecodedUATUplinkPacket::kDecodedPayloadNumBytes];
+        UATReedSolomon::DeInterleaveUplinkMessage(payload, raw.encoded_message);
+
         uint8_t buf[GDL90Reporter::kGDL90MessageMaxLenBytes];
         uint16_t msg_len = gdl90.WriteGDL90UplinkDataMessage(
-            buf, sizeof(buf), packet.decoded_payload, DecodedUATUplinkPacket::kDecodedPayloadNumBytes,
-            GDL90Reporter::MLAT48MHz64BitCountsToUATTORTicks(packet.raw.mlat_48mhz_64bit_counts));
+            buf, sizeof(buf), payload, DecodedUATUplinkPacket::kDecodedPayloadNumBytes,
+            GDL90Reporter::MLAT48MHz64BitCountsToUATTORTicks(raw.mlat_48mhz_64bit_counts));
 
         for (uint16_t i = 0; i < num_sinks; i++) {
             ret &= SendBuf(sinks[i], (char*)buf, msg_len);

--- a/firmware/common/coprocessor/object_dictionary.cpp
+++ b/firmware/common/coprocessor/object_dictionary.cpp
@@ -22,7 +22,7 @@ const uint8_t ObjectDictionary::kFirmwareVersionMajor = 0;
 const uint8_t ObjectDictionary::kFirmwareVersionMinor = 10;
 const uint8_t ObjectDictionary::kFirmwareVersionPatch = 0;
 // NOTE: Indicate a final release with RC = 0.
-const uint8_t ObjectDictionary::kFirmwareVersionReleaseCandidate = 5;
+const uint8_t ObjectDictionary::kFirmwareVersionReleaseCandidate = 6;
 
 const uint32_t ObjectDictionary::kFirmwareVersion = (kFirmwareVersionMajor << 24) | (kFirmwareVersionMinor << 16) |
                                                     (kFirmwareVersionPatch << 8) | kFirmwareVersionReleaseCandidate;

--- a/firmware/common/utils/fec/fec.cpp
+++ b/firmware/common/utils/fec/fec.cpp
@@ -72,59 +72,57 @@ int UATReedSolomon::DecodeUplinkMessage(uint8_t decoded_payload_buf[RawUATUplink
     }
     int total_bytes_corrected = 0;
 
-    // PrintByteBuffer("DecodeUplinkMessage: Encoded message before decode:", encoded_message_buf,
-    //                 RawUATUplinkPacket::kUplinkMessageNumBytes);
-    // We need a buffer that's bigger than the payload size to de-interleave and decode with, since each block has its
-    // parity bytes overlapped with the next block, so the last block hangs over the payload length a bit.
-    uint8_t assembly_buf[RawUATUplinkPacket::kUplinkMessagePayloadNumBytes +
-                         RawUATUplinkPacket::kUplinkMessageBlockFECParityNumBytes] = {0};
+    // Each of the 6 blocks is de-interleaved into its own 92-byte scratch buffer, RS-corrected there, and the corrected
+    // codeword is scattered back into encoded_message_buf. The RS decoder corrects errors at any position in the block
+    // (parity symbols included) and the code is systematic, so the corrected 92-byte codeword is byte-identical to what
+    // re-encoding the corrected 72-byte payload would produce -- there is no need for a separate encode pass to leave
+    // the interleaved message in a corrected state.
+    uint8_t block_buf[RawUATUplinkPacket::kUplinkMessageBlockNumBytes];
     for (int block = 0; block < RawUATUplinkPacket::kUplinkMessageNumBlocks; block++) {
-        uint8_t* block_data_and_parity =
-            &(assembly_buf[block * RawUATUplinkPacket::kUplinkMessageBlockPayloadNumBytes]);
         for (int byte_index = 0; byte_index < RawUATUplinkPacket::kUplinkMessageBlockNumBytes; byte_index++) {
             // De-interleave per UAT tech manual Table 2-6.
-            block_data_and_parity[byte_index] =
-                encoded_message_buf[byte_index * RawUATUplinkPacket::kUplinkMessageNumBlocks + block];
+            block_buf[byte_index] = encoded_message_buf[byte_index * RawUATUplinkPacket::kUplinkMessageNumBlocks + block];
         }
 
-        // Decode with 0 erasures (erasures list is nullptr).
-        // PrintByteBuffer("\tBlock data before decode:", block_data_and_parity,
-        //                 RawUATUplinkPacket::kUplinkMessageBlockNumBytes);
-        int num_bytes_corrected = decode_rs_char(rs_uplink, block_data_and_parity, nullptr, 0);
-        // PrintByteBuffer("\tBlock data after decode:", block_data_and_parity,
-        //                 RawUATUplinkPacket::kUplinkMessageBlockNumBytes);
-        // CONSOLE_INFO("UATReedSolomon", "\tDecoded UAT uplink message block %d with %d bytes corrected.", block,
-        //  num_bytes_corrected);
+        // Decode with 0 erasures (erasures list is nullptr). Corrects block_buf in place.
+        int num_bytes_corrected = decode_rs_char(rs_uplink, block_buf, nullptr, 0);
         if (num_bytes_corrected < 0 || num_bytes_corrected > kUplinkMessageMaxNumByteCorrectionsPerBlock) {
-            return -1;  // Invalid message.
+            return -1;  // Invalid message. Blocks decoded so far may already have been corrected in place.
         }
+
+        if (num_bytes_corrected > 0) {
+            // Write the corrected codeword (payload + parity) back into the interleaved message so that callers hold a
+            // corrected encoded message without an encode pass.
+            for (int byte_index = 0; byte_index < RawUATUplinkPacket::kUplinkMessageBlockNumBytes; byte_index++) {
+                encoded_message_buf[byte_index * RawUATUplinkPacket::kUplinkMessageNumBlocks + block] =
+                    block_buf[byte_index];
+            }
+        }
+        memcpy(&(decoded_payload_buf[block * RawUATUplinkPacket::kUplinkMessageBlockPayloadNumBytes]), block_buf,
+               RawUATUplinkPacket::kUplinkMessageBlockPayloadNumBytes);
 
         total_bytes_corrected += num_bytes_corrected;
     }
 
-    memcpy(decoded_payload_buf, assembly_buf, RawUATUplinkPacket::kUplinkMessagePayloadNumBytes);
     return total_bytes_corrected;
 }
 
 void UATReedSolomon::DeInterleaveUplinkMessage(
     uint8_t deinterleaved_buf[RawUATUplinkPacket::kUplinkMessagePayloadNumBytes],
-    uint8_t encoded_message_buf[RawUATUplinkPacket::kUplinkMessageNumBytes]) {
+    const uint8_t encoded_message_buf[RawUATUplinkPacket::kUplinkMessageNumBytes]) {
     if (encoded_message_buf == nullptr || deinterleaved_buf == nullptr) {
         return;  // Invalid input.
     }
 
-    uint8_t assembly_buf[RawUATUplinkPacket::kUplinkMessagePayloadNumBytes] = {0};
+    // De-interleave straight into the output (the buffers never alias in practice, and the gather pattern below reads
+    // each source byte exactly once, so no intermediate assembly buffer is needed).
     for (int block = 0; block < RawUATUplinkPacket::kUplinkMessageNumBlocks; block++) {
-        uint8_t* block_data_and_parity =
-            &(assembly_buf[block * RawUATUplinkPacket::kUplinkMessageBlockPayloadNumBytes]);
+        uint8_t* block_data = &(deinterleaved_buf[block * RawUATUplinkPacket::kUplinkMessageBlockPayloadNumBytes]);
         for (int byte_index = 0; byte_index < RawUATUplinkPacket::kUplinkMessageBlockPayloadNumBytes; byte_index++) {
             // De-interleave per UAT tech manual Table 2-6.
-            block_data_and_parity[byte_index] =
-                encoded_message_buf[byte_index * RawUATUplinkPacket::kUplinkMessageNumBlocks + block];
+            block_data[byte_index] = encoded_message_buf[byte_index * RawUATUplinkPacket::kUplinkMessageNumBlocks + block];
         }
     }
-
-    memcpy(deinterleaved_buf, assembly_buf, RawUATUplinkPacket::kUplinkMessagePayloadNumBytes);
 }
 
 bool UATReedSolomon::EncodeShortADSBMessage(uint8_t message_buf[]) {

--- a/firmware/common/utils/fec/fec.cpp
+++ b/firmware/common/utils/fec/fec.cpp
@@ -114,8 +114,8 @@ void UATReedSolomon::DeInterleaveUplinkMessage(
         return;  // Invalid input.
     }
 
-    // De-interleave straight into the output (the buffers never alias in practice, and the gather pattern below reads
-    // each source byte exactly once, so no intermediate assembly buffer is needed).
+    // De-interleave straight into the output. Requires the buffers not to overlap (documented in fec.hh); with that
+    // guarantee no intermediate assembly buffer is needed.
     for (int block = 0; block < RawUATUplinkPacket::kUplinkMessageNumBlocks; block++) {
         uint8_t* block_data = &(deinterleaved_buf[block * RawUATUplinkPacket::kUplinkMessageBlockPayloadNumBytes]);
         for (int byte_index = 0; byte_index < RawUATUplinkPacket::kUplinkMessageBlockPayloadNumBytes; byte_index++) {

--- a/firmware/common/utils/fec/fec.hh
+++ b/firmware/common/utils/fec/fec.hh
@@ -50,7 +50,11 @@ class UATReedSolomon {
      * Transform an already corrected (but interleaved) raw UAT uplink payload into a de-interleaved payload that can be
      * used directly. Does not apply FEC, just de-interleaves and tosses out the parity bytes. Static since it needs no
      * Reed-Solomon state.
-     * @param[out] deinterleaved_buf Buffer to store the de-interleaved payload in.
+     *
+     * The de-interleave is performed directly into deinterleaved_buf (no intermediate copy), so the two buffers MUST
+     * NOT overlap. In practice they never do -- the output is a 432-byte payload buffer and the input is a separate
+     * 552-byte encoded message buffer -- but callers must not pass aliasing pointers.
+     * @param[out] deinterleaved_buf Buffer to store the de-interleaved payload in. Must not overlap encoded_message_buf.
      * @param[in] encoded_message_buf Buffer with the encoded message to de-interleave. Must be a valid message with FEC
      * corrections pre-applied.
      */

--- a/firmware/common/utils/fec/fec.hh
+++ b/firmware/common/utils/fec/fec.hh
@@ -34,23 +34,27 @@ class UATReedSolomon {
     int DecodeLongADSBMessage(uint8_t message_buf[]);
 
     /**
-     * Attempt decoding of a UAT uplink message.
-     * @param[out] decoded_payload_buf Buffer to store the decoded payload in. If decode is successful, buffer will be
-     * modified.
-     * @param[in] encoded_message_buf Buffer with the encoded message to decode.
-     * @return Number of bits corrected. 0 if message had no errors, positive number if errors were corrected, -1 if
+     * Attempt decoding of a UAT uplink message. Corrects the interleaved encoded message IN PLACE as a side effect: on
+     * success, encoded_message_buf holds the corrected codeword (payload and parity), so downstream consumers can
+     * de-interleave it directly (DeInterleaveUplinkMessage) without a further FEC pass. On failure, blocks decoded
+     * before the failing block may already have been corrected in place; callers are expected to discard the message.
+     * @param[out] decoded_payload_buf Buffer to store the decoded (de-interleaved, parity-stripped) payload in. May be
+     * partially written on failure.
+     * @param[in,out] encoded_message_buf Buffer with the encoded message to decode. Corrected in place.
+     * @return Number of bytes corrected. 0 if message had no errors, positive number if errors were corrected, -1 if
      * message was invalid and not correctable.
      */
     int DecodeUplinkMessage(uint8_t decoded_payload_buf[], uint8_t encoded_message_buf[]);
 
     /**
      * Transform an already corrected (but interleaved) raw UAT uplink payload into a de-interleaved payload that can be
-     * used directly. Does not apply FEC, just de-interleaves and tosses out the parity bytes.
+     * used directly. Does not apply FEC, just de-interleaves and tosses out the parity bytes. Static since it needs no
+     * Reed-Solomon state.
      * @param[out] deinterleaved_buf Buffer to store the de-interleaved payload in.
      * @param[in] encoded_message_buf Buffer with the encoded message to de-interleave. Must be a valid message with FEC
      * corrections pre-applied.
      */
-    void DeInterleaveUplinkMessage(uint8_t deinterleaved_buf[], uint8_t encoded_message_buf[]);
+    static void DeInterleaveUplinkMessage(uint8_t deinterleaved_buf[], const uint8_t encoded_message_buf[]);
 
     /**
      * Test functions used to turning test messages (provided without FEC headers) into encoded messages similar to what


### PR DESCRIPTION


* CMakeLists.txt defaults CMAKE_BUILD_TYPE to Release.
* fec.cpp: DecodeUplinkMessage now corrects the interleaved raw message in place (per-block scratch, scatter corrected codeword back) — the re-encode pass and its per-packet CONSOLE_INFO are gone from uat_packet.cpp. DeInterleaveUplinkMessage is static.
* comms_reporting.cpp: ReportRaw/ReportBeast/ReportGDL90Uplink return immediately with zero sinks; GDL90 just de-interleaves the already-corrected raw packet (no second RS pass, no 1 KB stack object). Beast UAT builders now take raw packet types (beast_utils.hh).
* comms.cpp/comms.hh: 8 KB software TX ring; writes are queued and the UART2 write callback chains segments; bounded wait then whole-write drop under true overload (counted); DrainConsoleTx waits for the ring; SetBaudRate cancels/reset; drains added before reboot/bootloader in adsbee.cpp.
* cc13x4_cc26x4_nortos.lds: STACKSIZE = 32768.
* AT+RX_STATS? now also reports max_loop_us, tx_stalls, tx_drops, tx_ring_hw (reset with =RESET).